### PR TITLE
Multiple deployments

### DIFF
--- a/.github/workflows/build-and-deploy-general-api.yml
+++ b/.github/workflows/build-and-deploy-general-api.yml
@@ -120,8 +120,8 @@ jobs:
           else
             DEPLOYMENTS=(${{ env.K8S_NAME }})
           fi
-          echo $DEPLOYMENTS
+          echo $DEPLOYMENTS[0]
 
-          for DEPLOYMENT in DEPLOYMENTS; do
+          for DEPLOYMENT in $DEPLOYMENTS; do
             echo $DEPLOYMENT
           done

--- a/.github/workflows/build-and-deploy-general-api.yml
+++ b/.github/workflows/build-and-deploy-general-api.yml
@@ -113,10 +113,11 @@ jobs:
           kubectl config set-context deployer --cluster=arn:aws:eks:us-east-1:165158508528:cluster/eks-${{ inputs.webtier }} --user=github-actions
           kubectl config use-context deployer
 
-          if [ -n ${{ inputs.deployments }} ]
+          INPUTS_DEPLOYMENTS=${{ inputs.deployments }}
+          if [ -n $INPUTS_DEPLOYMENTS ]
           then
-            DEPLOYMENTS=${{ fromJson(inputs.deployments) }}
+            DEPLOYMENTS=(${{ fromJson(inputs.deployments) }})
           else
-            DEPLOYMENTS=(${{ env.K8S_NAME }}-${{ inputs.webtier }})
+            DEPLOYMENTS=(${{ env.K8S_NAME }})
           fi
           echo $DEPLOYMENTS

--- a/.github/workflows/build-and-deploy-general-api.yml
+++ b/.github/workflows/build-and-deploy-general-api.yml
@@ -121,4 +121,16 @@ jobs:
 
           for DEPLOYMENT in "${DEPLOYMENTS[@]}"; do
             echo "$DEPLOYMENT"
+            # Create the K8s deployment, service and ingress if it doesn't exist.  Initially this will point to
+            # the repo's :sb or :prod tag, which was created in the publish step.  Then we'll point it to the
+            # exact version tag.
+            RESPONSE=$(kubectl get deployment/${DEPLOYMENT}-${{ inputs.webtier }}-deployment --ignore-not-found)
+            if [ -z $RESPONSE ]
+            then
+              kubectl create --save-config -f config/k8s/${DEPLOYMENT}-${{ inputs.webtier }}.yaml
+            else
+              kubectl apply -f config/k8s/${DEPLOYMENT}-${{ inputs.webtier }}.yaml
+            fi
+
+            kubectl set image deployment/${DEPLOYMENT}-${{ inputs.webtier }}-deployment ${DEPLOYMENT}-${{ inputs.webtier }}=${{ env.IMAGE_TAG }}
           done

--- a/.github/workflows/build-and-deploy-general-api.yml
+++ b/.github/workflows/build-and-deploy-general-api.yml
@@ -113,7 +113,7 @@ jobs:
           kubectl config set-context deployer --cluster=arn:aws:eks:us-east-1:165158508528:cluster/eks-${{ inputs.webtier }} --user=github-actions
           kubectl config use-context deployer
 
-          INPUTS_DEPLOYMENTS=${{ inputs.deployments }}
+          INPUTS_DEPLOYMENTS="${{ inputs.deployments }}"
           if [ -n $INPUTS_DEPLOYMENTS ]
           then
             DEPLOYMENTS=(${{ fromJson(inputs.deployments) }})
@@ -121,3 +121,7 @@ jobs:
             DEPLOYMENTS=(${{ env.K8S_NAME }})
           fi
           echo $DEPLOYMENTS
+
+          for DEPLOYMENT in DEPLOYMENTS; do
+            echo $DEPLOYMENT
+          done

--- a/.github/workflows/build-and-deploy-general-api.yml
+++ b/.github/workflows/build-and-deploy-general-api.yml
@@ -114,7 +114,7 @@ jobs:
           kubectl config use-context deployer
 
           INPUTS_DEPLOYMENTS="${{ inputs.deployments }}"
-          if [ -n $INPUTS_DEPLOYMENTS ]
+          if [ -n "$INPUTS_DEPLOYMENTS" ]
           then
             DEPLOYMENTS=(${{ fromJson(inputs.deployments) }})
           else

--- a/.github/workflows/build-and-deploy-general-api.yml
+++ b/.github/workflows/build-and-deploy-general-api.yml
@@ -120,19 +120,3 @@ jobs:
             DEPLOYMENTS=(${{ env.K8S_NAME }}-${{ inputs.webtier }})
           fi
           echo $DEPLOYMENTS
-
-          # for DEPLOYMENT in DEPLOYMENTS; do
-          #   echo $DEPLOYMENT
-          #   # Create the K8s deployment, service and ingress if it doesn't exist.  Initially this will point to
-          #   # the repo's :sb or :prod tag, which was created in the publish step.  Then we'll point it to the
-          #   # exact version tag.
-          #   RESPONSE=$(kubectl get deployment/${{ DEPLOYMENT }}-deployment --ignore-not-found)
-          #   if [ -z $RESPONSE ]
-          #   then
-          #     kubectl create --save-config -f config/k8s/${{ DEPLOYMENT }}.webtier }}.yaml
-          #   else
-          #     kubectl apply -f config/k8s/${{ DEPLOYMENT }}.webtier }}.yaml
-          #   fi
-
-          #   kubectl set image deployment/${{ DEPLOYMENT }}-deployment ${{ DEPLOYMENT }}=${{ env.IMAGE_TAG }}
-          # done

--- a/.github/workflows/build-and-deploy-general-api.yml
+++ b/.github/workflows/build-and-deploy-general-api.yml
@@ -121,18 +121,18 @@ jobs:
           fi
           echo $DEPLOYMENTS
 
-          for DEPLOYMENT in DEPLOYMENTS; do
-            echo $DEPLOYMENT
-            # Create the K8s deployment, service and ingress if it doesn't exist.  Initially this will point to
-            # the repo's :sb or :prod tag, which was created in the publish step.  Then we'll point it to the
-            # exact version tag.
-            RESPONSE=$(kubectl get deployment/${{ DEPLOYMENT }}-deployment --ignore-not-found)
-            if [ -z $RESPONSE ]
-            then
-              kubectl create --save-config -f config/k8s/${{ DEPLOYMENT }}.webtier }}.yaml
-            else
-              kubectl apply -f config/k8s/${{ DEPLOYMENT }}.webtier }}.yaml
-            fi
+          # for DEPLOYMENT in DEPLOYMENTS; do
+          #   echo $DEPLOYMENT
+          #   # Create the K8s deployment, service and ingress if it doesn't exist.  Initially this will point to
+          #   # the repo's :sb or :prod tag, which was created in the publish step.  Then we'll point it to the
+          #   # exact version tag.
+          #   RESPONSE=$(kubectl get deployment/${{ DEPLOYMENT }}-deployment --ignore-not-found)
+          #   if [ -z $RESPONSE ]
+          #   then
+          #     kubectl create --save-config -f config/k8s/${{ DEPLOYMENT }}.webtier }}.yaml
+          #   else
+          #     kubectl apply -f config/k8s/${{ DEPLOYMENT }}.webtier }}.yaml
+          #   fi
 
-            kubectl set image deployment/${{ DEPLOYMENT }}-deployment ${{ DEPLOYMENT }}=${{ env.IMAGE_TAG }}
-          done
+          #   kubectl set image deployment/${{ DEPLOYMENT }}-deployment ${{ DEPLOYMENT }}=${{ env.IMAGE_TAG }}
+          # done

--- a/.github/workflows/build-and-deploy-general-api.yml
+++ b/.github/workflows/build-and-deploy-general-api.yml
@@ -8,7 +8,7 @@ on:
       deployments:
         required: false
         type: string
-        description: "json string array of deployments to create"
+        description: "space-separated list of deployments to create"
     secrets:
       aws_access_key_id:
         required: true

--- a/.github/workflows/build-and-deploy-general-api.yml
+++ b/.github/workflows/build-and-deploy-general-api.yml
@@ -117,10 +117,8 @@ jobs:
           if (( ${#DEPLOYMENTS[@]} == 0 )); then
             DEPLOYMENTS=( ${{ env.K8S_NAME }} )
           fi
-          echo "${DEPLOYMENTS[*]}"
 
           for DEPLOYMENT in "${DEPLOYMENTS[@]}"; do
-            echo "$DEPLOYMENT"
             # Create the K8s deployment, service and ingress if it doesn't exist.  Initially this will point to
             # the repo's :sb or :prod tag, which was created in the publish step.  Then we'll point it to the
             # exact version tag.

--- a/.github/workflows/build-and-deploy-general-api.yml
+++ b/.github/workflows/build-and-deploy-general-api.yml
@@ -5,6 +5,10 @@ on:
       webtier:
         required: true
         type: string
+      deployments:
+        required: false
+        type: string
+        description: "json string array of deployments to create"
     secrets:
       aws_access_key_id:
         required: true
@@ -109,15 +113,26 @@ jobs:
           kubectl config set-context deployer --cluster=arn:aws:eks:us-east-1:165158508528:cluster/eks-${{ inputs.webtier }} --user=github-actions
           kubectl config use-context deployer
 
-          # Create the K8s deployment, service and ingress if it doesn't exist.  Initially this will point to
-          # the repo's :sb or :prod tag, which was created in the publish step.  Then we'll point it to the
-          # exact version tag.
-          RESPONSE=$(kubectl get deployment/${{ env.K8S_NAME }}-${{ inputs.webtier }}-deployment --ignore-not-found)
-          if [ -z $RESPONSE ]
+          if [ -n ${{ inputs.deployments }} ]
           then
-            kubectl create --save-config -f config/k8s/${{ env.K8S_NAME }}-${{ inputs.webtier }}.yaml
+            DEPLOYMENTS=${{ fromJson(inputs.deployments) }}
           else
-            kubectl apply -f config/k8s/${{ env.K8S_NAME }}-${{ inputs.webtier }}.yaml
+            DEPLOYMENTS=(${{ env.K8S_NAME }}-${{ inputs.webtier }})
           fi
+          echo $DEPLOYMENTS
 
-          kubectl set image deployment/${{ env.K8S_NAME }}-${{ inputs.webtier }}-deployment ${{ env.K8S_NAME }}-${{ inputs.webtier }}=${{ env.IMAGE_TAG }}
+          for DEPLOYMENT in DEPLOYMENTS; do
+            echo $DEPLOYMENT
+            # Create the K8s deployment, service and ingress if it doesn't exist.  Initially this will point to
+            # the repo's :sb or :prod tag, which was created in the publish step.  Then we'll point it to the
+            # exact version tag.
+            RESPONSE=$(kubectl get deployment/${{ DEPLOYMENT }}-deployment --ignore-not-found)
+            if [ -z $RESPONSE ]
+            then
+              kubectl create --save-config -f config/k8s/${{ DEPLOYMENT }}.webtier }}.yaml
+            else
+              kubectl apply -f config/k8s/${{ DEPLOYMENT }}.webtier }}.yaml
+            fi
+
+            kubectl set image deployment/${{ DEPLOYMENT }}-deployment ${{ DEPLOYMENT }}=${{ env.IMAGE_TAG }}
+          done

--- a/.github/workflows/build-and-deploy-general-api.yml
+++ b/.github/workflows/build-and-deploy-general-api.yml
@@ -113,15 +113,12 @@ jobs:
           kubectl config set-context deployer --cluster=arn:aws:eks:us-east-1:165158508528:cluster/eks-${{ inputs.webtier }} --user=github-actions
           kubectl config use-context deployer
 
-          INPUTS_DEPLOYMENTS="${{ inputs.deployments }}"
-          if [ -n "$INPUTS_DEPLOYMENTS" ]
-          then
-            DEPLOYMENTS=(${{ fromJson(inputs.deployments) }})
-          else
-            DEPLOYMENTS=(${{ env.K8S_NAME }})
+          DEPLOYMENTS=( ${{ inputs.deployments }} )
+          if (( ${#DEPLOYMENTS[@]} == 0 )); then
+            DEPLOYMENTS=( ${{ env.K8S_NAME }} )
           fi
           echo "${DEPLOYMENTS[*]}"
 
           for DEPLOYMENT in "${DEPLOYMENTS[@]}"; do
-            echo $DEPLOYMENT
+            echo "$DEPLOYMENT"
           done

--- a/.github/workflows/build-and-deploy-general-api.yml
+++ b/.github/workflows/build-and-deploy-general-api.yml
@@ -120,8 +120,8 @@ jobs:
           else
             DEPLOYMENTS=(${{ env.K8S_NAME }})
           fi
-          echo $DEPLOYMENTS[0]
+          echo "${DEPLOYMENTS[*]}"
 
-          for DEPLOYMENT in $DEPLOYMENTS; do
+          for DEPLOYMENT in "${DEPLOYMENTS[@]}"; do
             echo $DEPLOYMENT
           done


### PR DESCRIPTION
Support specifying multiple k8s deployments to create. Keeps the default behavior when not provided. eg.:

```
jobs:
  build-nodejs:
    uses: cuvmit/actions/.github/workflows/build-and-deploy-general-api.yml@multiple-deployments
    with:
      webtier: sb
      deployments: "ap-slides-worker-aperio ap-slides-finder-sfs ap-slides-worker-sfs"
```

https://github.com/cuvmit/ap_slides/pull/1